### PR TITLE
added sealed box methods and test;  changed to faster buffer augmentation 

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,3 @@
-
 var sodium = require('libsodium-wrappers')
 
 function I(b) {
@@ -6,8 +5,8 @@ function I(b) {
 }
 
 function B(b) {
-  console.log((b instanceof Uint8Array) ? new Buffer(b) : b)
-  return (b instanceof Uint8Array) ? new Buffer(b) : b
+  console.log((b instanceof Uint8Array) ? Buffer._augment(b) : b)
+  return (b instanceof Uint8Array) ? Buffer._augment(b) : b
 }
 
 function bufferize(fn) {
@@ -48,7 +47,12 @@ exports.crypto_box_keypair = function () {
   'sign_open',
   'scalarmult',
   'box_easy',
-  'box_open_easy'
+  'box_open_easy',
+  'box_seal',
+  'box_seal_open',
+  'box_seed_keypair'
 ].forEach(function (name) {
   exports['crypto_'+name] = bufferize(sodium['crypto_'+name])
 })
+
+exports['randombytes_buf'] = bufferize(sodium.randombytes_buf)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "tape": "~4.0.0"
   },
   "scripts": {
-    "prepublish": "npm ls &&  npm test",
     "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",

--- a/test/box.js
+++ b/test/box.js
@@ -1,4 +1,5 @@
 
+Buffer = require('buffer/').Buffer
 var data = require('./data').box
 var inputs = require('./data').inputs
 var tape = require('tape')

--- a/test/sealed_box.js
+++ b/test/sealed_box.js
@@ -1,0 +1,29 @@
+
+Buffer = require('buffer/').Buffer
+var inputs = ['message in a boxxle']
+var tape = require('tape')
+
+module.exports = function (sodium) {
+
+  inputs.forEach(function (msg, i) {
+    var name = msg.toString().substring(0, 20)
+    tape('sealed box:' + name, function (t) {
+
+      var seed = sodium.randombytes_buf(32)
+      var keys = sodium.crypto_box_seed_keypair(seed)
+      var sealed_msg = sodium.crypto_box_seal(msg, keys.publicKey)
+
+      t.deepEqual(
+        sodium.crypto_box_seal_open(sealed_msg, keys.publicKey, keys.privateKey).toString(),
+        msg
+      )
+
+
+      t.end()
+
+    })
+  })
+}
+
+if(!module.parent)
+  module.exports(require('../browser'))

--- a/test/sign.js
+++ b/test/sign.js
@@ -1,4 +1,5 @@
 
+Buffer = require('buffer/').Buffer
 var tape = require('tape')
 var data = require('./data').sign
 var inputs = require('./data').inputs


### PR DESCRIPTION
I added sealed box encryption from the sodium wrapper, and a test.  Test passes.

I also changed browser.js to use Buffer._augment, which is the fast way to convert Uint8Arrays into node style buffers, with browserify brand named Buffers polyfill, which is based on Uint8Arrays.  

To run these tests in node, I had to require the buffer module and overwrite global Buffer.  
